### PR TITLE
Honor LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ CP = cp -f
 	${CC} -c ${CFLAGS} $<
 	
 cdirip: ${OBJECTS}
-	${CC} -o $@ ${OBJECTS} -lm
+	${CC} ${LDFLAGS} -o $@ ${OBJECTS} -lm
 	
 all: cdirip
 


### PR DESCRIPTION
Hello @jozip,

I'm preparing to get cdirip packaged for the [pkgsrc](http://pkgsrc.org/) 2018Q3 release. We prefer that LDFLAGS are honored in the event [RELRO](https://wiki.netbsd.org/pkgsrc/hardening/) is enabled. I've [patched this in our work-in-progess repo](https://wip.pkgsrc.org/cgi-bin/gitweb.cgi?p=pkgsrc-wip.git;a=commitdiff;h=1b07f985ac9109a137f83908783bece11e9c02ed) but I would also like to get this changed "upstream".
jozip/cdirip seems to be the only place that cdirip is getting any attention so I though I would open the PR here.

Thanks!